### PR TITLE
sync: update Logic course thumbnails memory (v4 PNG)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,20 +122,27 @@ originSessionId: e5e3921c-331a-49f0-a353-6a23e46a094e
 ### feedback_logic_course_thumbnails.md
 
 ---
-name: Logic コースサムネイルは手書きフォント+図解スタイル
-description: Logic アプリのコース一覧サムネイルは手書きフォント＋図解で統一する。ダーク背景の「シーン」構成は方針外。
+name: Logic コースサムネイルは手書きフォント+図解スタイル（v4 PNG / Figma 製）
+description: Logic アプリのコース一覧サムネイルは Figma 制作 → PNG 書き出し（手書きフォント＋図解）で統一。SVG への巻き戻し禁止。
 type: feedback
 originSessionId: 7d04e427-5324-4d34-9f8f-c78e879fb838
 ---
-Logic アプリ（`public/images/v3/course-*.svg`）のコースサムネイルは「手書きフォント + 図解」スタイルで統一する。
+Logic アプリのコースサムネイルは **`public/images/v3/course-*.png`（v4、Figma 製、26 コース分）** をマスターとする。「手書きフォント + 図解」スタイル。
 
-**Why:** 2026-05-05 にマージされた PR #93 / #95 で23コース分のサムネイルがダーク背景 + 暖色スポット光のシーン構成（人物シルエット、机上の小物、夜空など）で実装されたが、Keita の本来の方針は「手書きフォント＋図解」だった。方針共有が抜けて23枚まるごと作り直しになった。
+**Why:**
+- 2026-05-05 PR #93 / #95 で23コース分が方針外（ダーク背景 + 写実シーン構成）でマージ → 全件作り直し
+- 2026-05-13 PR #140 で v4 PNG（Figma 製、Caveat フォント + クリーム notebook + 23 種図解）を投入し、コースサムネを正式にこのスタイルに統一
+- 同日 PR #156 が「`docs/HANDDRAWN_ROLLOUT_PLAN.md` の旧前提（既存 SVG = handdrawn の正解）」を信じて `courseData.ts` の `.png → .svg` 巻き戻しを実行 → 26 枚デグレ事故（PR #157 で revert）
 
 **How to apply:**
-- コースサムネイル / コース内図版を新規生成・差し替えする際は、必ず手書きフォント + 線画ベースの図解スタイルを採用する
+- 現行マスターは **`course-*.png`（v4 PNG）**。`courseData.ts` / `lessonSlides.ts` / `RoadmapScreenV3.tsx` の参照は **必ず `.png`** にする
+- legacy `course-*.svg`（インライン SVG + turbulence filter で擬似手書き）は参照しない。**「.png → .svg に戻す」変更は基本デグレと疑う**
+- 新規コース追加・サムネ作り直しは **v4 Figma マスター（https://www.figma.com/design/2SJYbSyMbBlSOyd3DJzbUc）** から複製 → PNG 書き出しが標準パイプライン
 - ダーク背景・写実的シーン・人物シルエット中心の構図は採用しない
-- 生成ツール（Pixa Ideogram v3 等）に渡すプロンプトには「handwritten font」「sketch」「diagram」「light/paper background」を明示する
-- サンプル1枚で承認を取ってから全体展開する（クレジット節約のため）
+- Pixa は使わない（[[feedback-no-pixa]]）。Gemini も Phase 2 以降で要なら検討だが、v4 では未使用
+- レッスンサムネ（lesson-*.webp、49 枚）と home/hero（4 枚）は未対応。Phase 2-3 で同じ notebook トーンに揃える
+- 関連 docs: `docs/HANDDRAWN_ROLLOUT_PLAN.md` / `docs/HANDDRAWN_STYLE_GUIDE.md`
+- サンプル1枚で承認を取ってから全体展開する（過去事故の再発防止）
 
 ### feedback_logic_marketing.md
 


### PR DESCRIPTION
## Summary
- agent-config から最新 memory を取り込み、`feedback_logic_course_thumbnails.md` を v4 PNG / Figma 製の現行マスター仕様に更新
- セッション開始時の bootstrap-rin.sh 経由で再生成された CLAUDE.md の差分を反映

## Context
ユーザーから「Hermes Agent でエラーが出てる」と報告あり（HTTP 200: Overloaded）。調査の結果、エラー自体は別ツール（Nous Research の Hermes Agent）の問題で、本リポでの修正対象ではないと判断。一方、セッション中に CLAUDE.md が memory sync で modified 状態になっていたため、stop hook の指摘に従って commit & push。

## Test plan
- [x] `git diff` で memory sync 由来の差分のみであることを確認
- [ ] レビュー後 main へ merge

https://claude.ai/code/session_018DyuknD9bFEAgcWLGQfrLR

---
_Generated by [Claude Code](https://claude.ai/code/session_018DyuknD9bFEAgcWLGQfrLR)_